### PR TITLE
Add IntelliJ inspections for certain style guidelines

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,95 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="AmbiguousFieldAccess" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="AmbiguousMethodCall" enabled="false" level="Style Warning" enabled_by_default="false" />
+    <inspection_tool class="AssertMessageNotString" enabled="true" level="Style Warning" enabled_by_default="true" />
+    <inspection_tool class="AssignmentToForLoopParameter" enabled="true" level="Notice" enabled_by_default="true">
+      <option name="m_checkForeachParameters" value="false" />
+    </inspection_tool>
+    <inspection_tool class="AssignmentToNull" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="AssignmentToStaticFieldFromInstanceMethod" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="AssignmentUsedAsCondition" enabled="true" level="Notice" enabled_by_default="true" />
+    <inspection_tool class="BreakStatementWithLabel" enabled="true" level="Notice" enabled_by_default="true" />
+    <inspection_tool class="CallToStringConcatCanBeReplacedByOperator" enabled="true" level="Style Warning" enabled_by_default="true" />
+    <inspection_tool class="CastToConcreteClass" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="ChainedEquality" enabled="true" level="Notice" enabled_by_default="true" />
+    <inspection_tool class="ClassNamingConvention" enabled="false" level="Style Warning" enabled_by_default="false">
+      <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
+      <option name="m_minLength" value="4" />
+      <option name="m_maxLength" value="64" />
+    </inspection_tool>
+    <inspection_tool class="ClassReferencesSubclass" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="ConfusingOctalEscape" enabled="false" level="TYPO" enabled_by_default="false" />
+    <inspection_tool class="ConstantNamingConvention" enabled="false" level="Style Warning" enabled_by_default="false">
+      <option name="onlyCheckImmutables" value="false" />
+      <option name="m_regex" value="[A-Z][A-Z_\d]*" />
+      <option name="m_minLength" value="5" />
+      <option name="m_maxLength" value="32" />
+    </inspection_tool>
+    <inspection_tool class="ContinueStatementWithLabel" enabled="true" level="Notice" enabled_by_default="true" />
+    <inspection_tool class="ControlFlowStatementWithoutBraces" enabled="true" level="Notice" enabled_by_default="true" />
+    <inspection_tool class="EqualsCalledOnEnumConstant" enabled="false" level="Style Warning" enabled_by_default="false" />
+    <inspection_tool class="ExtendsObject" enabled="false" level="Style Warning" enabled_by_default="false" />
+    <inspection_tool class="FallthruInSwitchStatement" enabled="true" level="Notice" enabled_by_default="true" />
+    <inspection_tool class="IncrementDecrementUsedAsExpression" enabled="true" level="Notice" enabled_by_default="true" />
+    <inspection_tool class="InstanceMethodNamingConvention" enabled="false" level="Style Warning" enabled_by_default="false">
+      <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+      <option name="m_minLength" value="4" />
+      <option name="m_maxLength" value="32" />
+    </inspection_tool>
+    <inspection_tool class="InstanceVariableNamingConvention" enabled="false" level="Style Warning" enabled_by_default="false">
+      <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+      <option name="m_minLength" value="0" />
+      <option name="m_maxLength" value="32" />
+    </inspection_tool>
+    <inspection_tool class="InstanceofInterfaces" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="InstanceofThis" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="InterfaceNamingConvention" enabled="false" level="Style Warning" enabled_by_default="false">
+      <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
+      <option name="m_minLength" value="8" />
+      <option name="m_maxLength" value="64" />
+    </inspection_tool>
+    <inspection_tool class="LabeledStatement" enabled="true" level="Notice" enabled_by_default="true" />
+    <inspection_tool class="ListIndexOfReplaceableByContains" enabled="false" level="Style Warning" enabled_by_default="false" />
+    <inspection_tool class="LiteralAsArgToStringEquals" enabled="false" level="TYPO" enabled_by_default="false" />
+    <inspection_tool class="LocalVariableNamingConvention" enabled="false" level="Style Warning" enabled_by_default="false">
+      <option name="m_ignoreForLoopParameters" value="false" />
+      <option name="m_ignoreCatchParameters" value="false" />
+      <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+      <option name="m_minLength" value="1" />
+      <option name="m_maxLength" value="20" />
+    </inspection_tool>
+    <inspection_tool class="LoggerInitializedWithForeignClass" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="loggerClassName" value="org.apache.log4j.Logger,org.slf4j.LoggerFactory,org.apache.commons.logging.LogFactory,java.util.logging.Logger" />
+      <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />
+    </inspection_tool>
+    <inspection_tool class="NestedAssignment" enabled="true" level="Notice" enabled_by_default="true" />
+    <inspection_tool class="OverlyStrongTypeCast" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoreInMatchingInstanceof" value="false" />
+    </inspection_tool>
+    <inspection_tool class="SimplifiableAnnotation" enabled="true" level="Style Warning" enabled_by_default="true" />
+    <inspection_tool class="StandardVariableNames" enabled="false" level="Notice" enabled_by_default="false" />
+    <inspection_tool class="SystemOutErr" enabled="false" level="Debugging" enabled_by_default="false" />
+    <inspection_tool class="ThrowablePrintStackTrace" enabled="false" level="Debugging" enabled_by_default="false" />
+    <inspection_tool class="TypeParameterNamingConvention" enabled="false" level="Style Warning" enabled_by_default="false">
+      <option name="m_regex" value="[A-Z]" />
+      <option name="m_minLength" value="1" />
+      <option name="m_maxLength" value="1" />
+    </inspection_tool>
+    <inspection_tool class="UnclearBinaryExpression" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UnnecessaryParentheses" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <option name="ignoreClarifyingParentheses" value="true" />
+      <option name="ignoreParenthesesOnConditionals" value="true" />
+      <option name="ignoreParenthesesOnLambdaParameter" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnqualifiedFieldAccess" enabled="true" level="Really Annoying" enabled_by_default="true" />
+    <inspection_tool class="UnqualifiedMethodAccess" enabled="true" level="Really Annoying" enabled_by_default="true" />
+    <inspection_tool class="UnqualifiedStaticUsage" enabled="true" level="Style Warning" enabled_by_default="true">
+      <option name="m_ignoreStaticFieldAccesses" value="false" />
+      <option name="m_ignoreStaticMethodCalls" value="false" />
+      <option name="m_ignoreStaticAccessFromStaticContext" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UpperCaseFieldNameNotConstant" enabled="false" level="Style Warning" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,58 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <info color="8e4900">
+      <option name="EFFECT_COLOR" value="808080" />
+      <option name="ERROR_STRIPE_COLOR" value="8e4900" />
+      <option name="myName" value="Debugging" />
+      <option name="myVal" value="50" />
+      <option name="myExternalName" value="Debugging" />
+      <option name="myDefaultAttributes">
+        <option name="ERROR_STRIPE_COLOR" value="8e4900" />
+      </option>
+    </info>
+    <info color="3b8059">
+      <option name="EFFECT_COLOR" value="28c786" />
+      <option name="ERROR_STRIPE_COLOR" value="3b8059" />
+      <option name="EFFECT_TYPE" value="5" />
+      <option name="myName" value="Style Warning" />
+      <option name="myVal" value="50" />
+      <option name="myExternalName" value="Style Warning" />
+      <option name="myDefaultAttributes">
+        <option name="ERROR_STRIPE_COLOR" value="3b8059" />
+      </option>
+    </info>
+    <info color="ff00">
+      <option name="FOREGROUND" value="ff00" />
+      <option name="BACKGROUND" value="ff9000" />
+      <option name="EFFECT_COLOR" value="ff00b5" />
+      <option name="ERROR_STRIPE_COLOR" value="ff00" />
+      <option name="myName" value="Really Annoying" />
+      <option name="myVal" value="50" />
+      <option name="myExternalName" value="Really Annoying" />
+      <option name="myDefaultAttributes">
+        <option name="ERROR_STRIPE_COLOR" value="ff00" />
+      </option>
+    </info>
+    <info color="525229">
+      <option name="EFFECT_COLOR" value="7d8084" />
+      <option name="myName" value="Notice" />
+      <option name="myVal" value="50" />
+      <option name="myExternalName" value="Notice" />
+      <option name="myDefaultAttributes" />
+    </info>
+    <list size="12">
+      <item index="0" class="java.lang.String" itemvalue="Debugging" />
+      <item index="1" class="java.lang.String" itemvalue="Style Warning" />
+      <item index="2" class="java.lang.String" itemvalue="Really Annoying" />
+      <item index="3" class="java.lang.String" itemvalue="Notice" />
+      <item index="4" class="java.lang.String" itemvalue="INFORMATION" />
+      <item index="5" class="java.lang.String" itemvalue="UNUSED ENTRY" />
+      <item index="6" class="java.lang.String" itemvalue="TYPO" />
+      <item index="7" class="java.lang.String" itemvalue="SERVER PROBLEM" />
+      <item index="8" class="java.lang.String" itemvalue="INFO" />
+      <item index="9" class="java.lang.String" itemvalue="WEAK WARNING" />
+      <item index="10" class="java.lang.String" itemvalue="WARNING" />
+      <item index="11" class="java.lang.String" itemvalue="ERROR" />
+    </list>
+  </settings>
+</component>


### PR DESCRIPTION
Note that this does not cover the entire style guide.

Add four new inspection profiles:
- "Notice" (gray box)
  - marks some constructs that should be used carefully, or may be confusing
- "Style Warning" (green dotted underline; dark green in error stripe)
  - marks style issues
- "Annoying" (green, orange background, pink box, green in error stripe)
  - marks specifically the case of missing "this" qualifiers
- "Debugging"

Enable thiese inspections:
- Ambiguous field and method use

Some of the inspections were not enabled, but have the appropriate styles
set, so they may be easily enabled.