### PR TITLE
Fixed travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@ language: java
 
 jdk:
   - oraclejdk8
+
+addons:
+apt:
+packages:
+  - oracle-java8-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ jdk:
   - oraclejdk8
 
 addons:
-apt:
-packages:
-  - oracle-java8-installer
+  apt:
+    packages:
+      - oracle-java8-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: java
 
-matrix:
-  include:
-    - jdk: oraclejdk8
-      addons:
-        apt:
-          packages:
-            - oracle-java8-installer
+jdk:
+  - oraclejdk8
+
+sudo: false
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: java
 
-jdk:
-  - oraclejdk8
-
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
+matrix:
+  include:
+    - jdk: oraclejdk8
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer

--- a/src/test/java/PathfinderTester.java
+++ b/src/test/java/PathfinderTester.java
@@ -1,5 +1,6 @@
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import main.algorithms.Pathfinder;
 import org.junit.Test;


### PR DESCRIPTION
Updated Travis to version 8u121. This gives it support for new javaFX classes like "alert". 
Also fixed an issue in pathfinderTester where we had not imported java.util.Arrays.